### PR TITLE
match styling for login/logout

### DIFF
--- a/Dental_Surgery/Pages/Login.cshtml
+++ b/Dental_Surgery/Pages/Login.cshtml
@@ -81,7 +81,7 @@
     <div class="d-flex justify-content-center align-items-center" style="min-height: calc(100vh - 56px);">
         <div class="login-card">
             <i class="fas fa-tooth fa-3x text-primary mb-3"></i>
-            <h3>Dental Login</h3>
+            <h3>Login</h3>
             <form method="post">
                 <div asp-validation-summary="All" class="text-danger"></div>
                 <!-- Email Field -->
@@ -100,11 +100,6 @@
 
                 <!-- Login Button -->
                 <button type="submit" class="btn btn-primary w-100">Login</button>
-
-                <!-- Forgot Password -->
-                <div class="forgot-password">
-                    <a href="#">Forgot Password?</a>
-                </div>
             </form>
             
             @section Scripts {

--- a/Dental_Surgery/Pages/Logout.cshtml
+++ b/Dental_Surgery/Pages/Logout.cshtml
@@ -6,9 +6,9 @@
 }
 
 <div class="container mt-5">
-    <div class="card shadow-sm mx-auto" style="max-width:500px;">
-        <div class="card-body text-center">
-            <h3 class="card-title mb-4 text-primary">Logout</h3>
+    <div class="d-flex justify-content-center align-items-center" style="min-height: calc(100vh - 400px);">
+        <div class="logout-card">
+            <h3>Logout</h3>
             <p>Are you sure you want to logout?</p>
 
             <form method="post" class="mt-4">
@@ -18,3 +18,23 @@
         </div>
     </div>
 </div>
+
+
+<style>
+    .logout-card {
+        background: white;
+        border-radius: 15px;
+        box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+        padding: 40px;
+        width: 100%;
+        max-width: 400px;
+        text-align: center;
+        margin-left: -100px;
+    }
+
+    .logout-card h3 {
+        font-weight: 600;
+        color: #007bff;
+        margin-bottom: 20px;
+    }
+</style>


### PR DESCRIPTION
- Login/logout pages look more similar, less jarring when you go from logout page > login page
- Removed 'forgot password' (typically you'd contact an admin to get a new password on a workplace system like this, not go through the forgot password process you'd have on a social media site or something) (also unless we add code to handle it, it's just a dead link)
- changed login title from 'Dental Login' to just 'Login'